### PR TITLE
GPII-3793: Initial take on Dockerfile and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,33 @@
-FROM alpine:3.9
+FROM golang:1.12.1-alpine3.9 AS build
+
+ENV SAA_RELEASE=master \
+    SAA_PROJECT=github.com/imduffy15/k8s-gke-service-account-assigner \
+    SAA_GIT_SHA=af04ba0acae0a90faa600390c6de93f521872cf4 \
+    CGO_ENABLED=0 \
+    LANG=C.UTF-8 \
+    ARCH=linux
+
+ENV SAA_GIT_REPO=https://${SAA_PROJECT}.git \
+    REPO_VERSION=${SAA_RELEASE}
+
+RUN apk add --update --no-cache \
+      curl \
+      git \
+      make \
+    && git clone --branch "${SAA_RELEASE}" --depth=1 -- "${SAA_GIT_REPO}" "${GOPATH}/src/${SAA_PROJECT}" \
+    && cd "${GOPATH}/src/${SAA_PROJECT}" \
+    && git show-ref --verify HEAD | grep -q "^${SAA_GIT_SHA}" \
+    && make setup \
+    && make -e build \
+    && mv /go/src/${SAA_PROJECT}/build/bin/${ARCH}/k8s-gke-service-account-assigner /service-account-assigner
+
+FROM scratch
+
+ENV SAA_UID=10000 \
+    SAA_GID=10000
+
+COPY --from=build /service-account-assigner /service-account-assigner
+
+USER ${SAA_UID}:${SAA_GID}
+
+ENTRYPOINT ["/service-account-assigner"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # docker-image-service-account-assigner
-Docker image for k8s-gke-service-account-assigner
+
+This is Docker image build of k8s-gke-service-account-assigner
+(https://github.com/imduffy15/k8s-gke-service-account-assigner).
+K8s-gke-service-account-assigner is a Kubernetes DaemonSet that acts as a proxy
+between individual pods and GCP metadata. This allows to provide different
+Google Service Accounts and Scopes for pods and protects compute instance
+Service Account access.
+
+## Building
+
+### Master
+
+On push/merge to master, CI will automatically build and push
+`gpii/service-account-assigner:latest` image.
+
+### Tags
+
+Create and push git tag and CI will build and publish corresponding`
+`gpii/service-account-assigner:${git_tag}` docker image.
+
+#### Tag format
+
+Tags should follow actual service-account-assigner version, suffixed by
+`-gpii.${gpii_build_number}`, where `gpii_build_number` is monotonically
+increasing number denoting Docker image build number,  starting from `0`
+for each upstream version.
+
+Example:
+```
+0.0.3-gpii.0
+0.0.3-gpii.1
+...
+0.0.4-gpii.0
+```
+
+### Manually
+
+Run `make` to see all available steps.
+
+- `make build` to build image as latest
+- `make push` to push this image to registry


### PR DESCRIPTION
Initial take on Docker image for Service Account Assigner.

This PR:
- Adds Dockerfile
- Adds README with a brief description of SAA and how to release image tags

As per our policy for 3rd party images, we build the image ourselves and verify the integrity of the checked-out code as a part of the build process.

Compared to the original image, this image introduces the following improvements:
- Based on `scratch` image - smaller size and attack surface, only the required binary is present
- Runs as non-root