### PR TITLE
GPII-3793: Add iptables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM golang:1.12.1-alpine3.9 AS build
 
-ENV SAA_RELEASE=master \
+ENV SAA_RELEASE=add-proxy-support \
     SAA_PROJECT=github.com/imduffy15/k8s-gke-service-account-assigner \
-    SAA_GIT_SHA=af04ba0acae0a90faa600390c6de93f521872cf4 \
+    SAA_FORK=github.com/stepanstipl/k8s-gke-service-account-assigner \
+    SAA_GIT_SHA=ef1e2f2c40a9b81e08ad246e32592d1a90ce491c \
     CGO_ENABLED=0 \
     LANG=C.UTF-8 \
     ARCH=linux
 
-ENV SAA_GIT_REPO=https://${SAA_PROJECT}.git \
+ENV SAA_GIT_REPO=https://${SAA_FORK}.git \
     REPO_VERSION=${SAA_RELEASE}
 
 RUN apk add --update --no-cache \
@@ -30,6 +31,7 @@ ENV SAA_UID=10000 \
     SAA_HOME=/opt/saa
 
 RUN apk add --update --no-cache \
+      ca-certificates \
       iptables \
       libcap \
     && mkdir -p "${SAA_HOME}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM golang:1.12.1-alpine3.9 AS build
 
-ENV SAA_RELEASE=add-proxy-support \
+ENV SAA_RELEASE=v0.0.2 \
     SAA_PROJECT=github.com/imduffy15/k8s-gke-service-account-assigner \
-    SAA_FORK=github.com/stepanstipl/k8s-gke-service-account-assigner \
-    SAA_GIT_SHA=ef1e2f2c40a9b81e08ad246e32592d1a90ce491c \
+    SAA_GIT_SHA=551204bc4de049eaaa4e6139684447103a97c8a2 \
     CGO_ENABLED=0 \
     LANG=C.UTF-8 \
     ARCH=linux
 
-ENV SAA_GIT_REPO=https://${SAA_FORK}.git \
+ENV SAA_GIT_REPO=https://${SAA_PROJECT}.git \
     REPO_VERSION=${SAA_RELEASE}
 
 RUN apk add --update --no-cache \


### PR DESCRIPTION
It turned out the Service Account assigner needs `iptables`, which I missed previously, and as it's a dynamically linked binary we need to pull in the whole Alpine image.

This PR:
- Adds `iptables` (and therefore Alpine) to the runtime Docker image
- Sets capabilities and permissions to allow non-root account (saa) to use those
- Add `ca-certificates`
- Add support to build from fork

This depends on gpii-ops/k8s-gke-service-account-assigner/pull/1 and after that PR is merged, the `SAA_FORK` and `SAA_GIT_SHA` needs to be updated to point to `gpii-ops` fork and corresponding SHA.

(after merge this should be tagged as `master-gpii.1`)